### PR TITLE
Formfeed->Page

### DIFF
--- a/src/jzon.lisp
+++ b/src/jzon.lisp
@@ -123,7 +123,7 @@
                     ((nil) (%raise 'json-eof-error "Unexpected end of input after '\\' in string"))
                     ((#.(char "\"" 0) #\\ #\/) escaped)
                     (#\b #\Backspace)
-                    (#\f #\Formfeed)
+                    (#\f #\Page)
                     (#\n #\Linefeed)
                     (#\r #\Return)
                     (#\t #\Tab)
@@ -629,7 +629,7 @@
                 (#\Backspace
                  (write-char #\\ stream)
                  (write-char #\b stream))
-                (#\Formfeed
+                (#\Page
                  (write-char #\\ stream)
                  (write-char #\f stream))
                 (#\Linefeed

--- a/test/jzon-tests.lisp
+++ b/test/jzon-tests.lisp
@@ -262,7 +262,7 @@
 (test string-expands-special-escapes
   (is-every string=
     (#\Backspace (parse "\"\\b\""))
-    (#\Formfeed  (parse "\"\\f\""))
+    (#\Page  (parse "\"\\f\""))
     (#\Linefeed  (parse "\"\\n\""))
     (#\Return    (parse "\"\\r\""))
     (#\Tab       (parse "\"\\t\""))))
@@ -284,7 +284,7 @@
 (test stringify-string-handles-special-escapes
   (is-every string=
     ("\"\\b\"" (stringify (string #\Backspace)))
-    ("\"\\f\"" (stringify (string #\Formfeed)))
+    ("\"\\f\"" (stringify (string #\Page)))
     ("\"\\n\"" (stringify (string #\Linefeed)))
     ("\"\\r\"" (stringify (string #\Return)))
     ("\"\\t\"" (stringify (string #\Tab)))))


### PR DESCRIPTION
CLHS mentions Page as "The form-feed or page-separator character",
both ECL and ABCL don't recognize Formfeed, while in SBCL it's an
alias for Page. So changing Formfeed to Page in jzon makes it work
with ECL and ABCL in addition to SBCL.

(Tested with SBCL 2.1.8, ECL 21.2.1, ABCL 1.8.0 and HEAD of jzon)