### PR TITLE
Stringify replacer

### DIFF
--- a/src/jzon.lisp
+++ b/src/jzon.lisp
@@ -812,6 +812,7 @@ see `with-object'"
       (when (eq context :object-value)
         (%write-indentation writer)))
     (write-char #\} %stream)
+
     (unless %stack
       (push :complete %stack)))
   writer)


### PR DESCRIPTION
Adds a slot to the `json-writer` class specifying a function to apply to key-value pairs during stringification.