### PR TITLE
`allow-multiple-content` Support

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -4,7 +4,8 @@
 
 Changes relative to [v1.0.0](#v100)
 
-* `allow-extra-content` in reader functions now prevents jzon from scanning content after the toplevel object to signal error. Can be used to support formats like [JSON Lines][json-lines].
+* `jzon:parse-next` no longer 'over-reads' strings, objects, and arrays.
+* `allow-multiple-content` in reader functions now prevents jzon from scanning content after the toplevel object to signal error. Can be used to support formats like [JSON Lines][json-lines].
 * faster parsing from (vector (unsigned-byte 8)) and binary streams https://github.com/Zulu-Inuoe/jzon/issues/29
 * bugfix - `allow-trailing-comma` was not being properly applied when reading from vectors or pathnames
 * bugfix - `max-string-length` was not being properly applied when reading from vectors or pathnames

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -4,6 +4,7 @@
 
 Changes relative to [v1.0.0](#v100)
 
+* `allow-extra-content` in reader functions now prevents jzon from scanning content after the toplevel object to signal error. Can be used to support formats like [JSON Lines][json-lines].
 * faster parsing from (vector (unsigned-byte 8)) and binary streams https://github.com/Zulu-Inuoe/jzon/issues/29
 * bugfix - `allow-trailing-comma` was not being properly applied when reading from vectors or pathnames
 * bugfix - `max-string-length` was not being properly applied when reading from vectors or pathnames
@@ -22,3 +23,5 @@ Incompatible changes relative to [v1.0.0](#v100):
 Initial Release
 
 :tada:
+
+[json-lines]: https://jsonlines.org/

--- a/README.md
+++ b/README.md
@@ -175,6 +175,16 @@ When reading a stream we can call [`jzon:parse`](#jzonparse) several times:
   (jzon:parse s :allow-multiple-content t)) #| => 3 |#
 ```
 
+:warning: When reading numbers, `null`, `false`, or `true`, they **must** be followed by whitespace. [`jzon:parse`](#jzonparse) shall signal an error otherwise:
+
+```lisp
+(jzon:parse "123[1, 2, 3]" :allow-multiple-content t) #| error |#
+```
+
+This is to prevent errors caused by the lookahead necessary for parsing non-delimited tokens.
+
+This is not required when using [`jzon:parse-next`](#jzonparse-next).
+
 ##### *key-fn*
 
 When parsing objects, *key-fn* is called on each of that object's keys (`simple-string`):

--- a/README.md
+++ b/README.md
@@ -118,7 +118,7 @@ As noted, `jzon:parse` and `jzon:stringify` suit most use-cases, this section go
 
 ### jzon:parse
 
-*Function* **jzon:parse** *in &key max-depth allow-comments allow-trailing-comma max-string-length key-fn*
+*Function* **jzon:parse** *in &key max-depth allow-comments allow-trailing-comma allow-multiple-content max-string-length key-fn*
 
 *=> value* 
 
@@ -126,6 +126,7 @@ As noted, `jzon:parse` and `jzon:stringify` suit most use-cases, this section go
 * *max-depth* - a positive `integer`, or a boolean
 * *allow-comments* - a `boolean`
 * *allow-trailing-comma* - a `boolean`
+* *allow-multiple-content* - a `boolean`
 * *max-string-length* - `nil`, `t`, or a positive `integer`
 * *key-fn* - a designator for a function of one argument, or a boolean
 
@@ -145,6 +146,7 @@ Reads JSON from `in` and returns a `jzon:json-element` per [Type Mappings](#type
 The keyword arguments control optional features when reading:
 * `:allow-comments` controls if we allow single-line // comments and /**/ multiline block comments.
 * `:allow-trailing-comma` controls if we allow a single comma `,` after all elements of an array or object.
+* `:allow-multiple-content` controls if we allow for more than one element at the 'toplevel' *see below*
 * `:key-fn` is a function of one value which is called on object keys as they are read, or a boolean *(see below)*
 * `:max-depth` controls the maximum depth allowed when nesting arrays or objects.
 * `:max-string-length` controls the maximum length allowed when reading a string key or value.
@@ -155,6 +157,23 @@ The keyword arguments control optional features when reading:
 * `t` - Default limit
 
 When either *max-depth* or *max-string-length* is exceeded, `jzon:parse` shall signal a `jzon:json-parse-limit-error` error.
+
+##### *allow-multiple-content*
+
+JSON requires there  be only one toplevel element. Using *allow-multiple-content* tells `jzon:parse` to stop after reading one full toplevel element:
+
+```lisp
+(jzon:parse "1 2 3" :allow-multiple-content t) #| => 1 |#
+```
+
+When reading a stream we can call [`jzon:parse`](#jzonparse) several times:
+
+```lisp
+(with-input-from-string (s "1 2 3")
+  (jzon:parse s :allow-multiple-content t)  #| => 1 |#
+  (jzon:parse s :allow-multiple-content t)  #| => 2 |#
+  (jzon:parse s :allow-multiple-content t)) #| => 3 |#
+```
 
 ##### *key-fn*
 
@@ -843,13 +862,14 @@ An example:
 
 ### jzon:make-parser
 
-*Function* **jzon:make-parser** *in &key allow-comments allow-trailing-comma max-string-length key-fn*
+*Function* **jzon:make-parser** *in &key allow-comments allow-trailing-comma *allow-multiple-content* max-string-length key-fn*
 
 *=> writer*
 
 * *in* - a string, vector (unsigned-byte 8), stream, or pathname
 * *allow-comments* - a `boolean`
 * *allow-trailing-comma* - a `boolean`
+* *allow-multiple-content* - a `boolean`
 * *max-string-length* - a positive `integer`
 * *key-fn* - a designator for a function of one argument, or a boolean
 
@@ -869,6 +889,8 @@ The behaviour of `jzon:parser` is analogous to `jzon:parse`, except you control 
 * `pathname` - `jzon:make-parser` will open the file for reading in utf-8
 
 When *max-string-length* is exceeded, [`jzon:parse-next`](#jzonparse-next) shall signal a `jzon:json-parse-limit-error` error.
+
+JSON requires there  be only one toplevel element. Using *allow-multiple-content* allows parsing of multiple toplevel JSON elements. See [`jzon:parse-next`](#jzonparse-next) on how this affects the results.
 
 :warning: Because [`jzon:make-parser`](#jzonmake-parser) can open a file, it is recommended you use [`jzon:with-parser`](#jzonwith-parser) instead, unless you need indefinite extent.
 
@@ -926,6 +948,18 @@ Always returns two values indicating the next available event on the JSON stream
 **Note:** The `nil` *event* represents conclusion of a toplevel value, and should be taken as "parsing has successfully completed".
 
 When the parser's *max-string-length* is exceeded, [`jzon:parse-next`](#jzonparse-next) shall signal a `jzon:json-parse-limit-error` error. See [`jzon:make-parser`](#jzonmake-parser).
+
+##### *allow-multiple-content*
+
+When *allow-multiple-content* enabled in the [`jzon:parser`](#jzonparser), it shall emit the `nil` event after no more content is available.
+
+```lisp
+(jzon:with-parser (parser "1 2 3")
+  (jzon:parse-next parser)  #| :value, 1 |#
+  (jzon:parse-next parser)  #| :value, 2 |#
+  (jzon:parse-next parser)  #| :value, 3 |#
+  (jzon:parse-next parser)) #| nil, nil |#
+```
 
 ### Streaming Parser Example
 
@@ -1135,6 +1169,7 @@ I believe jzon to be the superior choice and hope for it to become the new, true
 
 [JSONRFC]: https://tools.ietf.org/html/rfc8259
 [JSONTestSuite]: https://github.com/nst/JSONTestSuite
+[json-lines]: https://jsonlines.org/
 [jsown]: https://github.com/madnificent/jsown
 [cl-json]: https://cl-json.common-lisp.dev/cl-json.html
 [jonathan]: https://github.com/Rudolph-Miller/jonathan

--- a/src/jzon.lisp
+++ b/src/jzon.lisp
@@ -642,6 +642,9 @@ see `json-atom'"
    (%allow-trailing-comma
     :initform nil
     :type boolean)
+   (%allow-multiple-content
+    :initform nil
+    :type boolean)
    (%key-fn
     :type function)
    (%max-string-length
@@ -676,11 +679,13 @@ see `%read-string'"
 (defun make-parser (in &key
                       (allow-comments nil)
                       (allow-trailing-comma nil)
+                      (allow-multiple-content nil)
                       (max-string-length (min #x100000 (1- array-dimension-limit)))
                       (key-fn t))
   "Construct a `parser' Read a JSON value from `in', which may be a vector, a stream, or a pathname.
  `:allow-comments' controls if we allow single-line // comments and /**/ multiline block comments.
  `:allow-trailing-comma' controls if we allow a single comma `,' after all elements of an array or object.
+ `:allow-multiple-content' controls if we alow extra content beyond a single toplevel JSON value.
  `:max-string-length' controls the maximum length allowed when reading a string key or value.
  `:key-fn' is a function of one value which 'pools' object keys, or `nil' to disable pooling, and `t' for the default pool.
 
@@ -700,12 +705,13 @@ see `close-parser'"
                                ((nil) (1- array-dimension-limit))
                                ((t)   #x100000)
                                (t     max-string-length))))
-      (with-slots (%step %read-string %pos %allow-comments %allow-trailing-comma %max-string-length %key-fn %close-action) parser
+      (with-slots (%step %read-string %pos %allow-comments %allow-trailing-comma %allow-multiple-content %max-string-length %key-fn %close-action %parser-state) parser
         (setf %close-action close-action)
         (setf (values %step %read-string %pos) (%make-fns input max-string-length))
 
         (setf %allow-comments (and allow-comments t))
         (setf %allow-trailing-comma (and allow-trailing-comma t))
+        (setf %allow-multiple-content (and allow-multiple-content t))
         (setf %key-fn (etypecase key-fn
                         (null     #'identity)
                         ((eql t)  (%make-string-pool))
@@ -738,7 +744,7 @@ see `close-parser'"
         (close-parser ,parser-sym)))))
 
 (declaim (inline %parse-next))
-(defun %parse-next (%parser-state %step %read-string %pos %key-fn %allow-trailing-comma %allow-comments)
+(defun %parse-next (%parser-state %step %read-string %pos %key-fn %allow-trailing-comma %allow-comments %allow-multiple-content)
   (declare (type %parser-state %parser-state)
            (type function %step %read-string %pos %key-fn)
            (type boolean %allow-trailing-comma)
@@ -869,8 +875,9 @@ see `close-parser'"
         (let ((lc (%skip-whitespace %step %pos (%parser-state-lookahead %parser-state) %allow-comments)))
           (setf (%parser-state-lookahead %parser-state) lc)
           (cond
-            (lc (%raise 'json-parse-error %pos "Content after reading element"))
-            (t  (values nil nil))))))))
+            ((null lc)                  (values nil nil))
+            (%allow-multiple-content    (read-element lc))
+            (t                          (%raise 'json-parse-error %pos "Content after reading element"))))))))
 
 (defun parse-next (parser)
   "Read the next token from `parser'.
@@ -890,8 +897,8 @@ see `close-parser'"
   (check-type parser parser)
   (when (null (slot-value parser '%close-action))
     (error 'json-error :format-control "The parser has been closed."))
-  (with-slots (%step %read-string %pos %key-fn %allow-trailing-comma %allow-comments %parser-state) parser
-    (%parse-next %parser-state %step %read-string %pos %key-fn %allow-trailing-comma %allow-comments)))
+  (with-slots (%step %read-string %pos %key-fn %allow-trailing-comma %allow-comments %allow-multiple-content %parser-state) parser
+    (%parse-next %parser-state %step %read-string %pos %key-fn %allow-trailing-comma %allow-comments %allow-multiple-content)))
 
 (defun %make-string-pool ()
   "Make a function for 'interning' strings in a pool."
@@ -920,7 +927,7 @@ see `close-parser'"
           (or (gethash key pool)
               (setf (gethash key pool) key)))))))
 
-(defun %parse (%step %read-string %pos %key-fn %max-depth %allow-comments %allow-trailing-comma)
+(defun %parse (%step %read-string %pos %key-fn %max-depth %allow-comments %allow-trailing-comma %allow-multiple-content)
   (declare (type function %step %read-string %pos %key-fn))
   (declare (type (integer 1 #xFFFF) %max-depth))
   (declare (type boolean %allow-comments %allow-trailing-comma))
@@ -936,7 +943,9 @@ see `close-parser'"
     (macrolet ((finish-value (value)
                  `(let ((value ,value))
                     (if (null stack)
-                      (setf top value)
+                      (if %allow-multiple-content
+                        (return value)
+                        (setf top value))
                       (let ((container (car stack)))
                         (if (listp container)
                           (progn (push value (the list (car stack)))
@@ -948,7 +957,7 @@ see `close-parser'"
                       (%raise-limit 'json-parse-limit-error %pos %max-depth "Maximum depth exceeded."))
                     (incf depth))))
       (loop
-        (multiple-value-bind (event value) (%parse-next %parser-state %step %read-string %pos %key-fn %allow-trailing-comma %allow-comments)
+        (multiple-value-bind (event value) (%parse-next %parser-state %step %read-string %pos %key-fn %allow-trailing-comma %allow-comments %allow-multiple-content)
           (declare (dynamic-extent event))
           (case event
             ((nil)          (return top))
@@ -977,12 +986,14 @@ see `close-parser'"
                    (max-depth 128)
                    (allow-comments nil)
                    (allow-trailing-comma nil)
+                   (allow-multiple-content nil)
                    (max-string-length (min #x100000 (1- array-dimension-limit)))
                    (key-fn t))
   "Read a JSON value from `in', which may be a vector, a stream, or a pathname.
  `:max-depth' controls the maximum depth allowed when nesting arrays or objects.
  `:allow-comments' controls if we allow single-line // comments and /**/ multiline block comments.
  `:allow-trailing-comma' controls if we allow a single comma `,' after all elements of an array or object.
+ `:allow-multiple-content' controls if we alow extra content beyond a single toplevel JSON value.
  `:max-string-length' controls the maximum length allowed when reading a string key or value.
  `:key-fn' is a function of one value which 'pools' object keys, or `nil' to disable pooling, and `t' for the default pool."
   (check-type max-depth (or boolean (integer 1 #xFFFF)))
@@ -1005,11 +1016,11 @@ see `close-parser'"
     (typecase in
       (pathname
        (with-open-file (in in :direction :input :external-format :utf-8)
-         (parse in :max-depth max-depth :allow-comments allow-comments :allow-trailing-comma allow-trailing-comma :max-string-length max-string-length :key-fn key-fn)))
+         (parse in :max-depth max-depth :allow-comments allow-comments :allow-trailing-comma allow-trailing-comma :allow-multiple-content allow-multiple-content :max-string-length max-string-length :key-fn key-fn)))
       (t
         (multiple-value-bind (%step %read-string %pos) (%make-fns in max-string-length)
           (declare (dynamic-extent %step %read-string %pos))
-          (%parse %step %read-string %pos key-fn max-depth (and allow-comments t) (and allow-trailing-comma t)))))))
+          (%parse %step %read-string %pos key-fn max-depth (and allow-comments t) (and allow-trailing-comma t) (and allow-multiple-content t)))))))
 
 (macrolet ((%coerced-fields-slots (element)
              `(let ((class (class-of ,element)))

--- a/test/jzon-tests.lisp
+++ b/test/jzon-tests.lisp
@@ -531,6 +531,12 @@
 (test parse-max-depth-defaults-when-t
   (signals (jzon:json-parse-limit-error) (jzon:parse (make-string 130 :initial-element #\[) :max-depth t)))
 
+(test parse-errors-on-multiple-content
+  (signals (jzon:json-parse-error) (jzon:parse "1 2")))
+
+(test parse-errors-on-extra-content
+  (is (= 1 (jzon:parse "1 2" :allow-extra-content t))))
+
 (def-suite incremental :in parsing)
 (in-suite incremental)
 
@@ -567,6 +573,16 @@
       (jzon:parse-next parser))
     (signals (jzon:json-parse-error)
       (jzon:parse-next parser))))
+
+(test parse-next-allows-multiple-content-when-asked
+  (jzon:with-parser (parser "42 24" :allow-multiple-content t)
+    (multiple-value-bind (event value) (jzon:parse-next parser)
+      (is (eq :value event))
+      (is (= value 42)))
+    (multiple-value-bind (event value) (jzon:parse-next parser)
+      (is (eq :value event))
+      (is (= value 24)))
+    (is (null (jzon:parse-next parser)))))
 
 (test multi-close-ok
   (jzon:with-parser (parser "{}")

--- a/test/jzon-tests.lisp
+++ b/test/jzon-tests.lisp
@@ -534,8 +534,102 @@
 (test parse-errors-on-multiple-content
   (signals (jzon:json-parse-error) (jzon:parse "1 2")))
 
-(test parse-errors-on-extra-content
-  (is (= 1 (jzon:parse "1 2" :allow-extra-content t))))
+(test parse-no-error-on-multiple-content-when-asked
+  (is (= 1 (jzon:parse "1 2" :allow-multiple-content t))))
+
+(test parse-doesnt-overread-on-multiple-content-null
+  (with-input-from-string (s "null  ")
+    (jzon:parse s :allow-multiple-content t)
+    (is (= 5 (file-position s)))))
+
+(test parse-doesnt-overread-on-multiple-content-false
+  (with-input-from-string (s "false  ")
+    (jzon:parse s :allow-multiple-content t)
+    (is (= 6 (file-position s)))))
+
+(test parse-doesnt-overread-on-multiple-content-true
+  (with-input-from-string (s "true  ")
+    (jzon:parse s :allow-multiple-content t)
+    (is (= 5 (file-position s)))))
+
+(test parse-doesnt-overread-on-multiple-content-1234
+  (with-input-from-string (s "1234  ")
+    (jzon:parse s :allow-multiple-content t)
+    (is (= 5 (file-position s)))))
+
+(test parse-doesnt-overread-on-multiple-content-string
+  (with-input-from-string (s "\"hello\"  ")
+    (jzon:parse s :allow-multiple-content t)
+    (is (= 7 (file-position s)))))
+
+(test parse-doesnt-overread-on-multiple-content-array
+  (with-input-from-string (s "[\"hello\"]  ")
+    (jzon:parse s :allow-multiple-content t)
+    (is (= 9 (file-position s))))
+  (with-input-from-string (s "[1,2]  ")
+    (jzon:parse s :allow-multiple-content t)
+    (is (= 5 (file-position s)))))
+
+(test parse-doesnt-overread-on-multiple-content-object
+  (with-input-from-string (s "{\"x\":2}  ")
+    (jzon:parse s :allow-multiple-content t)
+    (is (= 7 (file-position s)))))
+
+(test parse-needs-whitespace-for-bare-tokens-nullnull
+  (signals (jzon:json-parse-error) (jzon:parse "nullnull" :allow-multiple-content t)))
+
+(test parse-needs-whitespace-for-bare-tokens-nulllbrace
+  (signals (jzon:json-parse-error) (jzon:parse "null[" :allow-multiple-content t))
+  (signals (jzon:json-parse-error) (jzon:parse "null{" :allow-multiple-content t)))
+
+(test parse-needs-whitespace-for-bare-tokens-nullrbrace
+  (signals (jzon:json-parse-error) (jzon:parse "null]" :allow-multiple-content t))
+  (signals (jzon:json-parse-error) (jzon:parse "null}" :allow-multiple-content t)))
+
+(test parse-needs-whitespace-for-bare-tokens-falsequote
+  (signals (jzon:json-parse-error) (jzon:parse "false\"" :allow-multiple-content t)))
+
+(test parse-needs-whitespace-for-bare-tokens-falsefalse
+  (signals (jzon:json-parse-error) (jzon:parse "falsefalse" :allow-multiple-content t)))
+
+(test parse-needs-whitespace-for-bare-tokens-falselbrace
+  (signals (jzon:json-parse-error) (jzon:parse "false[" :allow-multiple-content t))
+  (signals (jzon:json-parse-error) (jzon:parse "false{" :allow-multiple-content t)))
+
+(test parse-needs-whitespace-for-bare-tokens-falserbrace
+  (signals (jzon:json-parse-error) (jzon:parse "false]" :allow-multiple-content t))
+  (signals (jzon:json-parse-error) (jzon:parse "false}" :allow-multiple-content t)))
+
+(test parse-needs-whitespace-for-bare-tokens-falsequote
+  (signals (jzon:json-parse-error) (jzon:parse "false\"" :allow-multiple-content t)))
+
+(test parse-needs-whitespace-for-bare-tokens-truetrue
+  (signals (jzon:json-parse-error) (jzon:parse "truetrue" :allow-multiple-content t)))
+
+(test parse-needs-whitespace-for-bare-tokens-truelbrace
+  (signals (jzon:json-parse-error) (jzon:parse "true[" :allow-multiple-content t))
+  (signals (jzon:json-parse-error) (jzon:parse "true{" :allow-multiple-content t)))
+
+(test parse-needs-whitespace-for-bare-tokens-truerbrace
+  (signals (jzon:json-parse-error) (jzon:parse "true]" :allow-multiple-content t))
+  (signals (jzon:json-parse-error) (jzon:parse "true}" :allow-multiple-content t)))
+
+(test parse-needs-whitespace-for-bare-tokens-truequote
+  (signals (jzon:json-parse-error) (jzon:parse "true\"" :allow-multiple-content t)))
+
+(test parse-needs-whitespace-for-bare-tokens-1234null
+  (signals (jzon:json-parse-error) (jzon:parse "1234null" :allow-multiple-content t)))
+
+(test parse-needs-whitespace-for-bare-tokens-1234lbrace
+  (signals (jzon:json-parse-error) (jzon:parse "1234[" :allow-multiple-content t))
+  (signals (jzon:json-parse-error) (jzon:parse "1234{" :allow-multiple-content t)))
+
+(test parse-needs-whitespace-for-bare-tokens-1234rbrace
+  (signals (jzon:json-parse-error) (jzon:parse "1234]" :allow-multiple-content t))
+  (signals (jzon:json-parse-error) (jzon:parse "1234}" :allow-multiple-content t)))
+
+(test parse-needs-whitespace-for-bare-tokens-1234quote
+  (signals (jzon:json-parse-error) (jzon:parse "1234\"" :allow-multiple-content t)))
 
 (def-suite incremental :in parsing)
 (in-suite incremental)
@@ -685,6 +779,62 @@
       (is (null (jzon:parse-next parser)))
       (is (not (eq x1 x2)))
       (is (not (eq x2 x3))))))
+
+(test parse-next-need-whitespace-for-bare-tokens-nullnull
+  (jzon:with-parser (p "nullnull" :allow-multiple-content t)
+    (signals (jzon:json-parse-error) (jzon:parse-next p))))
+
+(test parse-next-no-need-whitespace-for-bare-tokens-nulllbrace
+  (jzon:with-parser (p "null[" :allow-multiple-content t)
+    (is (eq :value (jzon:parse-next p))))
+  (jzon:with-parser (p "null{" :allow-multiple-content t)
+    (is (eq :value (jzon:parse-next p)))))
+
+(test parse-next-no-need-whitespace-for-bare-tokens-nullquote
+  (jzon:with-parser (p "null\"" :allow-multiple-content t)
+    (is (eq :value (jzon:parse-next p)))))
+
+(test parse-next-need-whitespace-for-bare-tokens-falsenull
+  (jzon:with-parser (p "falsenull" :allow-multiple-content t)
+    (signals (jzon:json-parse-error) (jzon:parse-next p))))
+
+(test parse-next-no-need-whitespace-for-bare-tokens-falselbrace
+  (jzon:with-parser (p "false[" :allow-multiple-content t)
+    (is (eq :value (jzon:parse-next p))))
+  (jzon:with-parser (p "false{" :allow-multiple-content t)
+    (is (eq :value (jzon:parse-next p)))))
+
+(test parse-next-no-need-whitespace-for-bare-tokens-falsequote
+  (jzon:with-parser (p "false\"" :allow-multiple-content t)
+    (is (eq :value (jzon:parse-next p)))))
+
+(test parse-next-need-whitespace-for-bare-tokens-truenull
+  (jzon:with-parser (p "truenull" :allow-multiple-content t)
+    (signals (jzon:json-parse-error) (jzon:parse-next p))))
+
+(test parse-next-no-need-whitespace-for-bare-tokens-truelbrace
+  (jzon:with-parser (p "true[" :allow-multiple-content t)
+    (is (eq :value (jzon:parse-next p))))
+  (jzon:with-parser (p "true{" :allow-multiple-content t)
+    (is (eq :value (jzon:parse-next p)))))
+
+(test parse-next-no-need-whitespace-for-bare-tokens-truequote
+  (jzon:with-parser (p "true\"" :allow-multiple-content t)
+    (is (eq :value (jzon:parse-next p)))))
+
+(test parse-next-need-whitespace-for-bare-tokens-1234null
+  (jzon:with-parser (p "1234null" :allow-multiple-content t)
+    (signals (jzon:json-parse-error) (jzon:parse-next p))))
+
+(test parse-next-no-need-whitespace-for-bare-tokens-1234lbrace
+  (jzon:with-parser (p "1234[" :allow-multiple-content t)
+    (is (eq :value (jzon:parse-next p))))
+  (jzon:with-parser (p "1234{" :allow-multiple-content t)
+    (is (eq :value (jzon:parse-next p)))))
+
+(test parse-next-no-need-whitespace-for-bare-tokens-1234quote
+  (jzon:with-parser (p "1234\"" :allow-multiple-content t)
+    (is (eq :value (jzon:parse-next p)))))
 
 (def-suite writer :in jzon)
 (in-suite writer)


### PR DESCRIPTION
Adds support for having multiple toplevel JSON elements, which additionally skips scanning past the first toplevel element after jzon:parse