### PR TITLE
ECL Support

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -4,6 +4,7 @@
 
 Changes relative to [v1.0.0](#v100)
 
+* [ECL][ecl] Support https://github.com/Zulu-Inuoe/jzon/issues/36
 * Add `jzon:parse-next-element` utility function for parsing a full element using the streaming reader.
 * bugfix - signal `jzon:json-eof-error` when we encounter an incomplete unicode escape sequence such as `\uAD`. Used to signal `cl:type-error`.
 * bugfix - `jzon:parse-next` no longer returns 3 values on `:object-key`
@@ -30,3 +31,4 @@ Initial Release
 :tada:
 
 [json-lines]: https://jsonlines.org/
+[ecl]: https://gitlab.com/embeddable-common-lisp/ecl

--- a/src/com.inuoe.jzon.asd
+++ b/src/com.inuoe.jzon.asd
@@ -5,7 +5,7 @@
   :license "MIT"
   :depends-on (#:closer-mop
                #:flexi-streams
-               #:float-features
+               (:feature (:not :ecl) #:float-features)
                #:trivial-gray-streams
                #:uiop)
   :components ((:file "eisel-lemire")

--- a/src/eisel-lemire.lisp
+++ b/src/eisel-lemire.lisp
@@ -1,6 +1,7 @@
 (defpackage #:com.inuoe.jzon/eisel-lemire
   (:use #:cl)
   (:local-nicknames
+    #-ecl
     (#:ff #:org.shirakumo.float-features))
   (:export #:make-double))
 
@@ -95,6 +96,15 @@
          (lo (ldb (byte 64 0) (* x y))))
     (values hi lo)))
 
+(defmacro %raw-int-bits-to-double (x)
+  #-ecl
+  `(ff:bits-double-float ,x)
+  #+ecl
+  (let ((double-tmp (gensym (string 'double-tmp))))
+    `(ffi:with-foreign-object (,double-tmp :double)
+      (setf (ffi:deref-pointer ,double-tmp :uint64-t) ,x)
+      (ffi:deref-pointer ,double-tmp :double))))
+
 (defun make-double (mantissa exp10 neg)
   (when (and (typep mantissa '(unsigned-byte 64))
              (typep exp10 '(signed-byte 32)))
@@ -138,4 +148,4 @@
                   ;;
                   (unless (>= (%uint64 (- ret-exp-2 1)) (- #x7FF 1))
                     (let ((ret-bits (logior (%<<u64 ret-exp-2 52) (logand ret-mantissa #x000FFFFFFFFFFFFF) (if neg #x8000000000000000 0))))
-                      (ff:bits-double-float ret-bits))))))))))))
+                      (%raw-int-bits-to-double ret-bits))))))))))))

--- a/src/eisel-lemire.lisp
+++ b/src/eisel-lemire.lisp
@@ -100,12 +100,12 @@
   #-ecl
   `(ff:bits-double-float ,x)
   #+ecl
-  #.(if (find-symbol (string '#:bits-double-float) '#:si)
-      `(list ',(intern (string '#:bits-double-float) '#:si) x)
-      '(let ((tmp (gensym (string 'tmp))))
-        `(ffi:with-foreign-object (,tmp :double)
-          (setf (ffi:deref-pointer ,tmp :uint64-t) ,x)
-          (ffi:deref-pointer ,tmp :double)))))
+  (if (find-symbol (string '#:bits-double-float) '#:si)
+    `(,(intern (string '#:bits-double-float) '#:si) ,x)
+    (let ((tmp (gensym (string 'tmp))))
+      `(ffi:with-foreign-object (,tmp :double)
+        (setf (ffi:deref-pointer ,tmp :uint64-t) ,x)
+        (ffi:deref-pointer ,tmp :double)))))
 
 (defun make-double (mantissa exp10 neg)
   (when (and (typep mantissa '(unsigned-byte 64))

--- a/src/eisel-lemire.lisp
+++ b/src/eisel-lemire.lisp
@@ -96,14 +96,16 @@
          (lo (ldb (byte 64 0) (* x y))))
     (values hi lo)))
 
-(defmacro %raw-int-bits-to-double (x)
+(defmacro %bits-double-float (x)
   #-ecl
   `(ff:bits-double-float ,x)
   #+ecl
-  (let ((double-tmp (gensym (string 'double-tmp))))
-    `(ffi:with-foreign-object (,double-tmp :double)
-      (setf (ffi:deref-pointer ,double-tmp :uint64-t) ,x)
-      (ffi:deref-pointer ,double-tmp :double))))
+  #.(if (find-symbol (string '#:bits-double-float) '#:si)
+      `(list ',(intern (string '#:bits-double-float) '#:si) x)
+      '(let ((tmp (gensym (string 'tmp))))
+        `(ffi:with-foreign-object (,tmp :double)
+          (setf (ffi:deref-pointer ,tmp :uint64-t) ,x)
+          (ffi:deref-pointer ,tmp :double)))))
 
 (defun make-double (mantissa exp10 neg)
   (when (and (typep mantissa '(unsigned-byte 64))
@@ -148,4 +150,4 @@
                   ;;
                   (unless (>= (%uint64 (- ret-exp-2 1)) (- #x7FF 1))
                     (let ((ret-bits (logior (%<<u64 ret-exp-2 52) (logand ret-mantissa #x000FFFFFFFFFFFFF) (if neg #x8000000000000000 0))))
-                      (%raw-int-bits-to-double ret-bits))))))))))))
+                      (%bits-double-float ret-bits))))))))))))

--- a/src/ratio-to-double.lisp
+++ b/src/ratio-to-double.lisp
@@ -1,15 +1,3 @@
-(eval-when (:compile-toplevel :load-toplevel :execute)
-  (flet ((#1=#:|| (package)
-          (unless (find-package package)
-            (cond
-              ((and (find-package '#:ql) (find-symbol (string '#:quickload) '#:ql))
-                (funcall (find-symbol (string '#:quickload) '#:ql) package))
-              ((and (find-package '#:asdf) (find-symbol (string '#:load-system) '#:asdf))
-                (funcall (find-symbol (string '#:load-system) '#:asdf) package))
-              (t
-                (require package))))))
-    (#1# '#:float-features)))
-
 ;;
 ;; This implementation was ported from the Clozure Common Lisp source
 ;;     CCL::%DOUBLE-FLOAT

--- a/src/ratio-to-double.lisp
+++ b/src/ratio-to-double.lisp
@@ -25,12 +25,12 @@
   #-ecl
   `(ff:bits-double-float ,x)
   #+ecl
-  #.(if (find-symbol (string '#:bits-double-float) '#:si)
-      `(list ',(intern (string '#:bits-double-float) '#:si) x)
-      '(let ((tmp (gensym (string 'tmp))))
-        (list 'ffi:with-foreign-object (list tmp :double)
-          (list 'setf (list 'ffi:deref-pointer tmp :uint64-t) x)
-          (list 'ffi:deref-pointer tmp :double)))))
+  (if (find-symbol (string '#:bits-double-float) '#:si)
+    `(,(intern (string '#:bits-double-float) '#:si) ,x)
+    (let ((tmp (gensym (string 'tmp))))
+      `(ffi:with-foreign-object (,tmp :double)
+        (setf (ffi:deref-pointer ,tmp :uint64-t) ,x)
+        (ffi:deref-pointer ,tmp :double)))))
 
 ;;; make a float from hi - high 24 bits mantissa (ignore implied higher bit)
 ;;;                   lo -  low 28 bits mantissa

--- a/src/schubfach.lisp
+++ b/src/schubfach.lisp
@@ -18,6 +18,7 @@
 (defpackage #:com.inuoe.jzon/schubfach
   (:use #:cl)
   (:local-nicknames
+    #-ecl
     (#:ff #:org.shirakumo.float-features))
   (:export
     #:write-float
@@ -236,7 +237,13 @@
         (%write-positive-int-digits q1 (- pos 2) buf ds)))))
 
 (defmacro %float-to-raw-int-bits (x)
-  `(the (unsigned-byte 32) (ff:single-float-bits ,x)))
+  #-ecl
+  `(the (unsigned-byte 32) (ff:single-float-bits ,x))
+  #+ecl
+  (let ((float-tmp (gensym (string 'float-tmp))))
+    `(ffi:with-foreign-object (,float-tmp :float)
+      (setf (ffi:deref-pointer ,float-tmp :float) ,x)
+      (ffi:deref-pointer ,float-tmp :uint32-t))))
 
 (defun %write-float (x buf
                       &aux
@@ -430,7 +437,13 @@
       (+ pos 3))))
 
 (defmacro %double-to-raw-long-bits (x)
-  `(the (unsigned-byte 64) (ff:double-float-bits ,x)))
+  #-ecl
+  `(the (unsigned-byte 64) (ff:double-float-bits ,x))
+  #+ecl
+  (let ((double-tmp (gensym (string 'double-tmp))))
+    `(ffi:with-foreign-object (,double-tmp :double)
+      (setf (ffi:deref-pointer ,double-tmp :double) ,x)
+      (ffi:deref-pointer ,double-tmp :uint64-t))))
 
 (defun %write-double (x buf
                       &aux

--- a/src/schubfach.lisp
+++ b/src/schubfach.lisp
@@ -236,19 +236,21 @@
 
         (%write-positive-int-digits q1 (- pos 2) buf ds)))))
 
-(defmacro %float-to-raw-int-bits (x)
+(defmacro %single-float-bits (x)
   #-ecl
   `(the (unsigned-byte 32) (ff:single-float-bits ,x))
   #+ecl
-  (let ((float-tmp (gensym (string 'float-tmp))))
-    `(ffi:with-foreign-object (,float-tmp :float)
-      (setf (ffi:deref-pointer ,float-tmp :float) ,x)
-      (ffi:deref-pointer ,float-tmp :uint32-t))))
+  #.(if (find-symbol (string '#:single-float-bits) '#:si)
+      `(list ',(intern (string '#:single-float-bits) '#:si) x)
+      '(let ((tmp (gensym (string 'tmp))))
+         `(ffi:with-foreign-object (,tmp :float)
+           (setf (ffi:deref-pointer ,tmp :float) ,x)
+           (ffi:deref-pointer ,tmp :uint32-t)))))
 
 (defun %write-float (x buf
                       &aux
                       (pos 0)
-                      (bits (%float-to-raw-int-bits x))
+                      (bits (%single-float-bits x))
                       (ds *%digits*)
                       (gs *%gs*))
   (declare (type single-float x)
@@ -436,19 +438,21 @@
       (setf (char buf (+ pos 2)) (code-char (ldb (byte 7 8) d)))
       (+ pos 3))))
 
-(defmacro %double-to-raw-long-bits (x)
+(defmacro %double-float-bits (x)
   #-ecl
   `(the (unsigned-byte 64) (ff:double-float-bits ,x))
   #+ecl
-  (let ((double-tmp (gensym (string 'double-tmp))))
-    `(ffi:with-foreign-object (,double-tmp :double)
-      (setf (ffi:deref-pointer ,double-tmp :double) ,x)
-      (ffi:deref-pointer ,double-tmp :uint64-t))))
+  #.(if (find-symbol (string '#:double-float-bits) '#:si)
+      `(list ',(intern (string '#:double-float-bits) '#:si) x)
+      '(let ((tmp (gensym (string 'tmp))))
+         `(ffi:with-foreign-object (,tmp :double)
+           (setf (ffi:deref-pointer ,tmp :double) ,x)
+           (ffi:deref-pointer ,tmp :uint64-t)))))
 
 (defun %write-double (x buf
                       &aux
                       (pos 0)
-                      (bits (%double-to-raw-long-bits x))
+                      (bits (%double-float-bits x))
                       (ds (load-time-value *%digits*))
                       (gs (load-time-value *%gs*)))
   (declare (type double-float x)

--- a/src/schubfach.lisp
+++ b/src/schubfach.lisp
@@ -240,12 +240,12 @@
   #-ecl
   `(the (unsigned-byte 32) (ff:single-float-bits ,x))
   #+ecl
-  #.(if (find-symbol (string '#:single-float-bits) '#:si)
-      `(list ',(intern (string '#:single-float-bits) '#:si) x)
-      '(let ((tmp (gensym (string 'tmp))))
-         `(ffi:with-foreign-object (,tmp :float)
-           (setf (ffi:deref-pointer ,tmp :float) ,x)
-           (ffi:deref-pointer ,tmp :uint32-t)))))
+  (if (find-symbol (string '#:single-float-bits) '#:si)
+    `(,(intern (string '#:single-float-bits) '#:si) ,x)
+    (let ((tmp (gensym (string 'tmp))))
+      `(ffi:with-foreign-object (,tmp :float)
+        (setf (ffi:deref-pointer ,tmp :float) ,x)
+        (ffi:deref-pointer ,tmp :uint32-t)))))
 
 (defun %write-float (x buf
                       &aux
@@ -442,12 +442,12 @@
   #-ecl
   `(the (unsigned-byte 64) (ff:double-float-bits ,x))
   #+ecl
-  #.(if (find-symbol (string '#:double-float-bits) '#:si)
-      `(list ',(intern (string '#:double-float-bits) '#:si) x)
-      '(let ((tmp (gensym (string 'tmp))))
-         `(ffi:with-foreign-object (,tmp :double)
-           (setf (ffi:deref-pointer ,tmp :double) ,x)
-           (ffi:deref-pointer ,tmp :uint64-t)))))
+  (if (find-symbol (string '#:double-float-bits) '#:si)
+    `(,(intern (string '#:double-float-bits) '#:si) ,x)
+    (let ((tmp (gensym (string 'tmp))))
+      `(ffi:with-foreign-object (,tmp :double)
+        (setf (ffi:deref-pointer ,tmp :double) ,x)
+        (ffi:deref-pointer ,tmp :uint64-t)))))
 
 (defun %write-double (x buf
                       &aux

--- a/test/com.inuoe.jzon-tests.asd
+++ b/test/com.inuoe.jzon-tests.asd
@@ -9,6 +9,6 @@
   (#:alexandria
    #:fiveam
    #:flexi-streams
-   #:float-features
+   (:feature (:not :ecl) #:float-features)
    #:com.inuoe.jzon
    #:uiop))

--- a/test/jzon-tests.lisp
+++ b/test/jzon-tests.lisp
@@ -58,12 +58,12 @@
   #-ecl
   `(ff:bits-double-float ,x)
   #+ecl
-  #.(if (find-symbol (string '#:bits-double-float) '#:si)
-      `(list ',(intern (string '#:bits-double-float) '#:si) x)
-      '(let ((tmp (gensym (string 'tmp))))
-        `(ffi:with-foreign-object (,tmp :double)
-          (setf (ffi:deref-pointer ,tmp :uint64-t) ,x)
-          (ffi:deref-pointer ,tmp :double)))))
+  (if (find-symbol (string '#:bits-double-float) '#:si)
+    `(,(intern (string '#:bits-double-float) '#:si) ,x)
+    (let ((tmp (gensym (string 'tmp))))
+      `(ffi:with-foreign-object (,tmp :double)
+        (setf (ffi:deref-pointer ,tmp :uint64-t) ,x)
+        (ffi:deref-pointer ,tmp :double)))))
 
 (test parses-atoms
   (is (eq 'null (jzon:parse "null")))

--- a/test/jzon-tests.lisp
+++ b/test/jzon-tests.lisp
@@ -54,13 +54,16 @@
 (defun not-simple (vector)
   (make-array (length vector) :element-type (array-element-type vector) :fill-pointer t :initial-contents vector))
 
-(defun bits-double-float (bits)
+(defmacro bits-double-float (x)
   #-ecl
-  (ff:bits-double-float bits)
+  `(ff:bits-double-float ,x)
   #+ecl
-  (ffi:with-foreign-object (double-tmp :double)
-    (setf (ffi:deref-pointer double-tmp :uint64-t) bits)
-    (ffi:deref-pointer double-tmp :double)))
+  #.(if (find-symbol (string '#:bits-double-float) '#:si)
+      `(list ',(intern (string '#:bits-double-float) '#:si) x)
+      '(let ((tmp (gensym (string 'tmp))))
+        `(ffi:with-foreign-object (,tmp :double)
+          (setf (ffi:deref-pointer ,tmp :uint64-t) ,x)
+          (ffi:deref-pointer ,tmp :double)))))
 
 (test parses-atoms
   (is (eq 'null (jzon:parse "null")))

--- a/test/jzon-tests.lisp
+++ b/test/jzon-tests.lisp
@@ -17,6 +17,7 @@
   (:import-from #:uiop)
   (:local-nicknames
    (#:jzon #:com.inuoe.jzon)
+   #-ecl
    (#:ff #:float-features)
    (#:fs #:flexi-streams))
   (:export

--- a/test/jzon-tests.lisp
+++ b/test/jzon-tests.lisp
@@ -1084,6 +1084,39 @@
         (loop :repeat 130 :do (jzon:begin-array*))
         (loop :repeat 130 :do (jzon:end-array*))))))
 
+(test writer-pretty-object-newlines-multiple-kv
+  (is (string= "{
+  \"x\": 0,
+  \"y\": 5
+}"
+               (with-writer-to-string (jzon:*writer* :pretty t)
+                 (jzon:write-object* "x" 0 "y" 5)))))
+
+(test writer-pretty-object-newlines-if-nested-object
+  (is (string= "{
+  \"obj\": {
+    \"x\": 0,
+    \"y\": 5
+  }
+}"
+               (with-writer-to-string (jzon:*writer* :pretty t)
+                 (jzon:with-object*
+                   (jzon:write-key* "obj")
+                   (jzon:write-object* "x" 0 "y" 5))))))
+
+(test writer-pretty-array-newlines-if-nested-object
+  (is (string= "[
+  1,
+  {
+    \"x\": 0,
+    \"y\": 5
+  }
+]"
+               (with-writer-to-string (jzon:*writer* :pretty t)
+                 (jzon:with-array*
+                   (jzon:write-value* 1)
+                   (jzon:write-object* "x" 0 "y" 5))))))
+
 (def-suite stringify :in jzon)
 
 (in-suite stringify)
@@ -1121,28 +1154,6 @@
   \"x\": 0
 }" (jzon:stringify (ph "x" 0) :pretty t))))
 
-(test stringify-pretty-object-newlines-multiple-kv
-  (is (string= "{
-  \"x\": 0,
-  \"y\": 5
-}" (jzon:stringify (ph "x" 0 "y" 5) :pretty t))))
-
-(test stringify-pretty-object-newlines-if-nested-object
-  (is (string= "{
-  \"obj\": {
-    \"x\": 0,
-    \"y\": 5
-  }
-}" (jzon:stringify (ph "obj" (ph "x" 0 "y" 5)) :pretty t))))
-
-(test stringify-pretty-array-newlines-if-nested-object
-  (is (string= "[
-  1,
-  {
-    \"x\": 0,
-    \"y\": 5
-  }
-]" (jzon:stringify (vector 1 (ph "x" 0 "y" 5)) :pretty t))))
 
 (test string-expands-special-escapes
   (is-every string=

--- a/test/jzon-tests.lisp
+++ b/test/jzon-tests.lisp
@@ -53,6 +53,14 @@
 (defun not-simple (vector)
   (make-array (length vector) :element-type (array-element-type vector) :fill-pointer t :initial-contents vector))
 
+(defun bits-double-float (bits)
+  #-ecl
+  (ff:bits-double-float bits)
+  #+ecl
+  (ffi:with-foreign-object (double-tmp :double)
+    (setf (ffi:deref-pointer double-tmp :uint64-t) bits)
+    (ffi:deref-pointer double-tmp :double)))
+
 (test parses-atoms
   (is (eq 'null (jzon:parse "null")))
   (is (eq 'null (jzon:parse "  null")))
@@ -146,40 +154,40 @@
   (is (eql 0 (jzon:parse "0"))))
 
 (test parses-negative-zero.0
-  (is (= (ff:bits-double-float #x8000000000000000) (jzon:parse "-0.0"))))
+  (is (= (bits-double-float #x8000000000000000) (jzon:parse "-0.0"))))
 
 (test parses-negative-zero
-  (is (= (ff:bits-double-float #x8000000000000000) (jzon:parse "-0"))))
+  (is (= (bits-double-float #x8000000000000000) (jzon:parse "-0"))))
 
 (test parse-1.31300000121E8
-  (is (= (ff:bits-double-float #x419F4DEA807BE76D) (jzon:parse "1.31300000121E8"))))
+  (is (= (bits-double-float #x419F4DEA807BE76D) (jzon:parse "1.31300000121E8"))))
 
 (test parse--1.31300000121E8
-  (is (= (ff:bits-double-float #xC19F4DEA807BE76D) (jzon:parse "-1.31300000121E8"))))
+  (is (= (bits-double-float #xC19F4DEA807BE76D) (jzon:parse "-1.31300000121E8"))))
 
 (test parse-23456789012E66
-  (is (= (ff:bits-double-float #x4FC9EE093A64B854) (jzon:parse "23456789012E66"))))
+  (is (= (bits-double-float #x4FC9EE093A64B854) (jzon:parse "23456789012E66"))))
 
 (test parse-0.000000000000000000000034567890120102012
-  (is (= (ff:bits-double-float #x3B44E51F35466432) (jzon:parse "0.000000000000000000000034567890120102012"))))
+  (is (= (bits-double-float #x3B44E51F35466432) (jzon:parse "0.000000000000000000000034567890120102012"))))
 
 (test parse-97924.49742786969
-  (is (= (ff:bits-double-float #x40F7E847F576ED07) (jzon:parse "97924.49742786969"))))
+  (is (= (bits-double-float #x40F7E847F576ED07) (jzon:parse "97924.49742786969"))))
 
 (test parse-22057.311791265754
-  (is (= (ff:bits-double-float #x40D58A53F4635A66) (jzon:parse "22057.311791265754"))))
+  (is (= (bits-double-float #x40D58A53F4635A66) (jzon:parse "22057.311791265754"))))
 
 (test parse-5e-324
-  (is (= (ff:bits-double-float #x0000000000000001) (jzon:parse "5e-324"))))
+  (is (= (bits-double-float #x0000000000000001) (jzon:parse "5e-324"))))
 
 (test parse-4.9E-324
-  (is (= (ff:bits-double-float #x0000000000000001) (jzon:parse "4.9E-324"))))
+  (is (= (bits-double-float #x0000000000000001) (jzon:parse "4.9E-324"))))
 
 (test parse-4.8E-324
-  (is (= (ff:bits-double-float #x0000000000000001) (jzon:parse "4.8E-324"))))
+  (is (= (bits-double-float #x0000000000000001) (jzon:parse "4.8E-324"))))
 
 (test parse-0.000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000005
-  (is (= (ff:bits-double-float #x0000000000000001) (jzon:parse "0.000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000005"))))
+  (is (= (bits-double-float #x0000000000000001) (jzon:parse "0.000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000005"))))
 
 (test parse-g-clef
   (is (string= #.(string (code-char #x1D11E)) (jzon:parse "\"\\uD834\\uDD1E\""))))


### PR DESCRIPTION
This adds ECL support by providing ECL-specific implementations of the `float-features` functions for converting to/from single/double floats and their bitwise representation.

This is a hack relying on FFI, but at this time I do not know of a better alternative.

Fixes #36