### PR TITLE
span: create 'substreams' from start to end bounds.

### DIFF
--- a/README.md
+++ b/README.md
@@ -230,14 +230,16 @@ This *may* help speed up parsing on highly heterogeneous JSON.
 
 *=> span*
 
-* *in* - a `string`, or `vector (unsigned-byte 8)`
+* *in* - a `string`, `stream` ' or `vector (unsigned-byte 8)`
 * *start, end* - bounding index designators of sequence. The defaults for *start* and *end* are 0 and nil, respectively.
 
 *span* a span object representing the range.
 
 #### Description
 
-Create a span to be used in [`jzon:parse`](#jzonparse), or [`jzon:make-parser`](#jzonparser) in order to specify a bounded *start* and *end* for a string or vector.
+Create a span to be used in [`jzon:parse`](#jzonparse), or [`jzon:make-parser`](#jzonparser) in order to specify a bounded *start* and *end* for a string, stream or vector.
+
+NOTE: For streams, only input streams are allowed.
 
 ##### Example
 

--- a/src/jzon.lisp
+++ b/src/jzon.lisp
@@ -1082,7 +1082,15 @@ see `close-parser'"
             (end (or end (length in))))
         (unless (<= 0 start end (length in))
           (error "The bounding indices ~A and ~A are bad for a sequence of length ~A." start end (length in)))
-        (make-instance '%octet-vector-span :vector in :start start :end end)))))
+        (make-instance '%octet-vector-span :vector in :start start :end end)))
+    (stream
+      (let ((start start)
+            (end (or end (file-length in))))
+        (unless (<= 0 start end (file-length in))
+          (error "The bounding indices ~A and ~A are bad for a stream of length ~A." start end (file-length in)))
+        (unless (input-stream-p in)
+          (error "The stream ~A is not an input stream." in))
+        (flexi-streams:make-flexi-stream in :element-type (stream-element-type in) :position start :bound end)))))
 
 (defun parse (in &key
                    (max-depth 128)


### PR DESCRIPTION
This feature was motivated by glTF .glb files. In them, JSON data is intermingled with binary data. A glTF parser like `cl-gltf` has a stream that is the binary data for the whole file, and knows the chunks or spans of JSON and binary. So we just use json:parse as usual with a new span/slice/substream of the original stream.