### PR TITLE
Feat: support asdf:test-system

### DIFF
--- a/src/com.inuoe.jzon.asd
+++ b/src/com.inuoe.jzon.asd
@@ -8,6 +8,7 @@
                (:feature (:not :ecl) #:float-features)
                #:trivial-gray-streams
                #:uiop)
+  :in-order-to ((test-op (test-op "com.inuoe.jzon-tests")))
   :components ((:file "eisel-lemire")
                (:file "ratio-to-double")
                (:file "schubfach")

--- a/test/com.inuoe.jzon-tests.asd
+++ b/test/com.inuoe.jzon-tests.asd
@@ -5,6 +5,8 @@
   :license "MIT"
   :components
   ((:file "jzon-tests"))
+  :perform
+  (test-op (o c) (symbol-call '#:com.inuoe.jzon-tests '#:run))
   :depends-on
   (#:alexandria
    #:fiveam


### PR DESCRIPTION
Now `jzon` can be tested with `(asdf:test-system 'com.inuoe.jzon)`.