### PR TITLE
Add LispWorks 8 for structure serialization

### DIFF
--- a/src/jzon.lisp
+++ b/src/jzon.lisp
@@ -1156,7 +1156,7 @@ Example return value:
 ")
     (:method (element)
       nil)
-    #+(or ccl clisp sbcl)
+    #+(or ccl clisp sbcl lispworks8)
     (:method ((element structure-object))
       (%coerced-fields-slots element))
     (:method ((element standard-object))


### PR DESCRIPTION
MOP for structure-objects is supported for CLOSER-MOP + LispWorks 8.

It might be supported for earlier versions of LispWorks, but since they are not supported by CLOSER-MOP, I've added the `lispworks8` feature explicitly.

I've tested the change with my LispWorks 8 (8.0.1 on macOS) installation successfully:

```lisp
(defstruct my-struct a b c)
=> MY-STRUCT

(setq inst (make-my-struct :a 1 :b 2 :c "the letter c"))
=> #S(MY-STRUCT :A 1 :B 2 :C "the letter c")

(jzon:stringify inst)
=> "{\"a\":1,\"b\":2,\"c\":\"the letter c\"}"
```