### PR TITLE
Added command to run the automated tests on ecl

### DIFF
--- a/test.bat
+++ b/test.bat
@@ -16,6 +16,11 @@
   (sb-sys:interactive-interrupt ()^
     (sb-ext:exit :code -1073741510 :abort t)))
 
+@set PORTABLE_TEST_EXP=^
+(progn (handler-case (uiop:quit (apply #'com.inuoe.jzon-tests:main (uiop:command-line-arguments)))^
+  (error ()^
+    (uiop:quit 2))))
+
 @sbcl^
  --noinform^
  --end-runtime-options^
@@ -27,6 +32,15 @@
  --eval "(asdf:load-asd #p""%JZON_TESTS_ASD_E%\"")"^
  --eval "(ql:quickload '#:com.inuoe.jzon-tests)"^
  --eval "%TEST_EXP%"
+@if %errorlevel% neq 0 exit /b %errorlevel%
+
+@ecl^
+ --norc^
+ --eval "(load """"~/quicklisp/setup.lisp"""")"^
+ --eval "(asdf:load-asd #p""%JZON_ASD_E%\"")"^
+ --eval "(asdf:load-asd #p""%JZON_TESTS_ASD_E%\"")"^
+ --eval "(ql:quickload '#:com.inuoe.jzon-tests)"^
+ --eval "%PORTABLE_TEST_EXP%"
 @if %errorlevel% neq 0 exit /b %errorlevel%
 
 @endlocal

--- a/test.sh
+++ b/test.sh
@@ -12,6 +12,12 @@ test_exp="
     (sb-ext:exit :code -1073741510 :abort t)))
 "
 
+portable_test_exp="
+(progn (handler-case (uiop:quit (apply #'com.inuoe.jzon-tests:main (uiop:command-line-arguments)))
+         (error ()
+           (uiop:quit 2))))
+"
+
 sbcl --noinform \
      --end-runtime-options \
      --no-sysinit \
@@ -28,5 +34,4 @@ ecl --norc \
     --eval "(asdf:load-asd #p\"$jzon_asd\")" \
     --eval "(asdf:load-asd #p\"$jzon_test_asd\")" \
     --eval "(ql:quickload :com.inuoe.jzon-tests)" \
-    --eval "(com.inuoe.jzon-tests:main)" \
-    --eval "(quit)"
+    --eval "$portable_test_exp"

--- a/test.sh
+++ b/test.sh
@@ -23,3 +23,9 @@ sbcl --noinform \
      --eval "(ql:quickload :com.inuoe.jzon-tests)" \
      --eval "$test_exp"
     
+ecl --eval "(load #p\"~/quicklisp/setup.lisp\")" \
+    --eval "(asdf:load-asd #p\"$jzon_asd\")" \
+    --eval "(asdf:load-asd #p\"$jzon_test_asd\")" \
+    --eval "(ql:quickload :com.inuoe.jzon-tests)" \
+    --eval "(com.inuoe.jzon-tests:main)" \
+    --eval "(quit)"

--- a/test.sh
+++ b/test.sh
@@ -23,7 +23,8 @@ sbcl --noinform \
      --eval "(ql:quickload :com.inuoe.jzon-tests)" \
      --eval "$test_exp"
     
-ecl --eval "(load #p\"~/quicklisp/setup.lisp\")" \
+ecl --norc \
+    --eval "(load #p\"~/quicklisp/setup.lisp\")" \
     --eval "(asdf:load-asd #p\"$jzon_asd\")" \
     --eval "(asdf:load-asd #p\"$jzon_test_asd\")" \
     --eval "(ql:quickload :com.inuoe.jzon-tests)" \


### PR DESCRIPTION
Hello! :-)

I tried to solve [Automated tests for ECL #37](https://github.com/Zulu-Inuoe/jzon/issues/37)
Since I didn't run into errors or interrupts when running the automated tests on ECL, 
I ommitted the HANDLER-CASE in the first try. 
Would you like to have a translation of the HANDLER-CASE for ECL?

I didn't find equivalents to the flags --noinform, --end-runtime-options and --disable-debugger for ECL.
I wasn't sure about the flag --no-trap-fpe for ECL which disables floating-point exceptions.

Luckily, on ECL only one test case is skipped and none fails. 

EDIT: I couldn't build ECL on windows so I only tested CCL on windows.
EDIT2: I tried to find a portable solution for part of the handler-case.