### PR TITLE
Fix wrong link to jzon:stringify in readme

### DIFF
--- a/README.md
+++ b/README.md
@@ -117,7 +117,7 @@ jzon cannonically maps types per the following chart:
 
 **Note** the usage of symbol `cl:null` as a sentinel for JSON `null`
 
-When writing, additional values are supported. Please see the section [jzon:stringify](#writing).
+When writing, additional values are supported. Please see the section [jzon:stringify](#jzonstringify).
 
 # Usage
 


### PR DESCRIPTION
In the readme, there was a link in the `#writing` section, it was supposed to point to the `#jzonstringify` section, but it was pointing back to `#writing`. ~~I got stuck in an infinite loop.~~