### PR TITLE
Fix `replacer' is not called when writing objects

### DIFF
--- a/src/jzon.lisp
+++ b/src/jzon.lisp
@@ -1583,6 +1583,7 @@ see `write-values'"
     writer)
   (:method ((writer writer) value)
     (let ((coerce-key (slot-value writer '%coerce-key))
+          (replacer (slot-value writer '%replacer))
           (fields (coerced-fields value)))
       (with-object writer
         (loop :for (name value . type-cell) :in fields
@@ -1596,8 +1597,15 @@ see `write-values'"
                                                     ((and (subtypep 'list type) (subtypep type 'list))
                                                      #())
                                                     (t 'null)))))
-                     (write-key writer key)
-                     (write-value writer coerced-value))))))
+                     (if replacer
+                         (multiple-value-call (lambda (write-p &optional (new-value nil value-changed-p))
+                                                (when write-p
+                                                  (write-key writer key)
+                                                  (write-value writer (if value-changed-p new-value value))))
+                           (funcall replacer key value))
+                         (progn
+                           (write-key writer key)
+                           (write-value writer coerced-value))))))))
   ;;; `json-atom' specializations
   (:method ((writer writer) (value (eql 't)))
     (%write-json-atom writer value))


### PR DESCRIPTION
See #79 

---

- no tests
- an `if` with a `progn`
- might be more performant if the `if replacer` is moved outside the loop, but it might not

Otherwise, is that good?

---

Here's the code to repro the bug:

```lisp

(defun json-replacer (key value)
  (declare (ignorable key))
  (typecase value
    (null t)
    (symbol (values t (string-downcase value)))
    (t t)))


;;; stringify'ing a hash-table: works

(let ((ht (make-hash-table)))
  (setf (gethash :slot ht) :keyword)
  (com.inuoe.jzon:stringify
   ht
   :replacer 'json-replacer))
;; => "{\"slot\":\"keyword\"}"
;; as expected


;;; stringify'ing an object: doesn't work

(defclass object () ((slot :initarg :slot)))

(com.inuoe.jzon:stringify
 (make-instance 'object :slot :keyword)
 :replacer 'json-replacer)
;; => "{\"slot\":\"KEYWORD\"}"
```