### PR TITLE
Drop `uiop` as a primary dependency

### DIFF
--- a/com.inuoe.jzon-tests.asd
+++ b/com.inuoe.jzon-tests.asd
@@ -3,8 +3,7 @@
   :description "Tests for the jzon library"
   :author "Wilfredo Velázquez-Rodríguez <zulu.inuoe@gmail.com>"
   :license "MIT"
-  :components
-  ((:file "jzon-tests"))
+  :components ((:module "test" :components ((:file "jzon-tests"))))
   :perform
   (test-op (o c) (symbol-call '#:com.inuoe.jzon-tests '#:run))
   :depends-on

--- a/com.inuoe.jzon.asd
+++ b/com.inuoe.jzon.asd
@@ -6,10 +6,11 @@
   :depends-on (#:closer-mop
                #:flexi-streams
                (:feature (:not :ecl) #:float-features)
-               #:trivial-gray-streams
-               #:uiop)
+               #:trivial-gray-streams)
   :in-order-to ((test-op (test-op "com.inuoe.jzon-tests")))
-  :components ((:file "eisel-lemire")
-               (:file "ratio-to-double")
-               (:file "schubfach")
-               (:file "jzon" :depends-on ("eisel-lemire" "ratio-to-double" "schubfach"))))
+  :components ((:module "src"
+                :components ((:file "eisel-lemire")
+                             (:file "ratio-to-double")
+                             (:file "schubfach")
+                             (:file "jzon" :depends-on ("eisel-lemire" "ratio-to-double" "schubfach"))))))
+

--- a/src/jzon.lisp
+++ b/src/jzon.lisp
@@ -1866,5 +1866,18 @@ see `write-object'"
          (with-output-to-string (stream)
            (stringify-to stream)))
         (t
-          (stringify-to stream)
-          nil)))))
+         (stringify-to stream)
+         nil)))))
+
+;; NOTE: Borrowed from UIOP.
+(defun native-namestring (x)
+  "From a non-wildcard CL pathname, a return namestring suitable for passing to the operating system"
+  (when x
+    (let ((p (pathname x)))
+      #+clozure (with-pathname-defaults () (ccl:native-translated-namestring p)) ; see ccl bug 978
+      #+(or cmucl scl) (ext:unix-namestring p nil)
+      #+sbcl (sb-ext:native-namestring p)
+      #-(or clozure cmucl sbcl scl)
+      (os-cond
+       ((os-unix-p) (unix-namestring p))
+       (t (namestring p))))))


### PR DESCRIPTION
Removing `UIOP` as a main dependency reduces final binary sizes but also improves compatibility in certain scenarios (WASM). 

This PR also moves the `.asd` files to match convention, but I'm happy to undo that if you prefer them where they were.